### PR TITLE
Use java.util.random for DiceRoller

### DIFF
--- a/src/smims/networking/model/DiceRoller.java
+++ b/src/smims/networking/model/DiceRoller.java
@@ -1,14 +1,19 @@
 package smims.networking.model;
 
-public class DiceRoller {
+import java.util.Random;
 
+public class DiceRoller {
+	private static final int SidesOnADie = 6;
+	private final Random random = new Random();
 	private int result;
 	
 	public DiceRoller() {}
 	
 	public void rollDice()
 	{
-		result = (int)(Math.random()*6);
+		// nextInt returns an value x where 0 <= x < bound; the result must
+		// be increased by one to conform to real-world die.
+		result = random.nextInt(SidesOnADie) + 1;
 	}
 	
 	public int getResult()


### PR DESCRIPTION
Uses java.util.random instead of math.Random because it is better
practice when generating a sequence of random numbers rather than just a
single one.